### PR TITLE
Log deletion of model

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -17,7 +17,7 @@ trait LogsActivity
     {
         static::eventsToBeRecorded()->each(function ($eventName) {
             return static::$eventName(function (Model $model) use ($eventName) {
-                if ($eventName != 'deleted' && (!count(array_except($model->getDirty(), $model->attributesToBeIgnored()))))
+                if ($eventName != 'deleted' && (!count(array_except($model->getDirty(), $model->attributesToBeIgnored())))) {
                     return;
                 }
 

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -17,7 +17,7 @@ trait LogsActivity
     {
         static::eventsToBeRecorded()->each(function ($eventName) {
             return static::$eventName(function (Model $model) use ($eventName) {
-                if (! count(array_except($model->getDirty(), $model->attributesToBeIgnored()))) {
+                if ($eventName != 'deleted' && (!count(array_except($model->getDirty(), $model->attributesToBeIgnored()))))
                     return;
                 }
 


### PR DESCRIPTION
There is a bug concerning the deletion of models that has been fixed in the origina repository (see spatie/laravel-activitylog#47, fixed by https://github.com/spatie/laravel-activitylog/commit/da1cc70b84be4cac85fe30da7c2d49122eb7b78f). 

This PR applies the same fix as the one upstream and as far as I tested, the `deleted` event is now properly logged